### PR TITLE
copy fix from lagoon-core PR and rename image-inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,16 @@ To compile GraphQL schema, type-safe structs and response data with genqlient we
 
     go generate
 
-    
-    
+## Configmap labels
+
+```json
+  "labels": {
+    "lagoon.sh/project": "lagoon",
+    "lagoon.sh/environment": "main",
+    "lagoon.sh/service": "cli",
+    "lagoon.sh/insightsType": ["sbom", "image"],
+    "lagoon.sh/insightsOutputCompressed": ["true", "false" (default)] (optional),
+    "lagoon.sh/insightsOutputFileExt": ["json (default)", "txt", "csv", "html", "jpg"] (optional),
+    "lagoon.sh/insightsOutputFileMIMEType": ["text/html", "image/svg+xml"]  (optional)
+  }
+```

--- a/internal/handler/main.go
+++ b/internal/handler/main.go
@@ -319,13 +319,18 @@ func processingIncomingMessageQueueFactory(h *Messaging) func(mq.Message) {
 				fmt.Errorf("%s", err.Error())
 			}
 			return
-		} else {
-			if len(incoming.Payload) != 0 {
-				insights.InputPayload = Payload
-			}
-			if len(incoming.BinaryPayload) != 0 {
-				insights.InputPayload = BinaryPayload
-			}
+		}
+		if len(incoming.Payload) != 0 {
+			insights.InputPayload = Payload
+		}
+		if len(incoming.BinaryPayload) != 0 {
+			insights.InputPayload = BinaryPayload
+		}
+
+		// Debug
+		if h.EnableDebug {
+			log.Println("[DEBUG] insights:", insights)
+			log.Println("[DEBUG] target:", resource)
 		}
 
 		// Process s3 upload
@@ -338,9 +343,6 @@ func processingIncomingMessageQueueFactory(h *Messaging) func(mq.Message) {
 
 		// Process Lagoon API integration
 		if !h.LagoonAPI.Disabled {
-			log.Println(insights)
-			log.Println(insights.InsightsType)
-			log.Println(insights.InputType)
 
 			if insights.InsightsType != Sbom && insights.InsightsType != ImageInspect {
 				log.Println("only 'sbom' and 'image-inspect' types are currently supported for api processing")
@@ -350,13 +352,13 @@ func processingIncomingMessageQueueFactory(h *Messaging) func(mq.Message) {
 					log.Printf("Unable to send to the api: %s", err.Error())
 				}
 			}
-
 		}
 
+		// Ack to remove from queue
 		err := message.Ack(false)
 		if err != nil {
 			fmt.Errorf("%s", err.Error())
-		} // ack to remove from queue
+		}
 	}
 }
 
@@ -472,49 +474,42 @@ func (h *Messaging) processSbomInsightsData(insights InsightsData, v string, api
 }
 
 func (h *Messaging) processImageInspectInsightsData(insights InsightsData, v string, apiClient graphql.Client, resource ResourceDestination) error {
-	if insights.OutputCompressed {
-		decoded, err := decodeGzipString(v)
-		if err != nil {
-			fmt.Errorf(err.Error())
-		}
+	decoded, err := decodeGzipString(v)
+	if err != nil {
+		fmt.Errorf(err.Error())
+	}
 
-		project, environment, apiErr := determineResourceFromLagoonAPI(apiClient, resource)
-		if apiErr != nil {
-			return apiErr
-		}
-		source := fmt.Sprintf("image-inspect:%s", resource.Service)
+	project, environment, apiErr := determineResourceFromLagoonAPI(apiClient, resource)
+	if apiErr != nil {
+		return apiErr
+	}
+	source := fmt.Sprintf("image-inspect:%s", resource.Service)
 
-		marshallDecoded, err := json.Marshal(decoded)
-		var imageInspect ImageInspectData
-		err = json.Unmarshal(marshallDecoded, &imageInspect)
-		if err != nil {
-			return err
-		}
+	marshallDecoded, err := json.Marshal(decoded)
+	var imageInspect ImageInspectData
+	err = json.Unmarshal(marshallDecoded, &imageInspect)
+	if err != nil {
+		return err
+	}
 
-		facts, err := processFactsFromImageInspect(imageInspect, environment.Id, source)
-		if err != nil {
-			return err
-		}
-		log.Printf("Successfully decoded image-inspect")
+	facts, err := processFactsFromImageInspect(imageInspect, environment.Id, source)
+	if err != nil {
+		return err
+	}
+	log.Printf("Successfully decoded image-inspect")
 
-		facts, err = keyFactsFilter(facts)
-		if err != nil {
-			return err
-		}
+	if len(facts) == 0 {
+		return fmt.Errorf("no facts to process")
+	}
 
-		if len(facts) == 0 {
-			return fmt.Errorf("no facts to process")
-		}
+	apiErr = h.deleteExistingFactsBySource(apiClient, environment, source, project)
+	if apiErr != nil {
+		return apiErr
+	}
 
-		apiErr = h.deleteExistingFactsBySource(apiClient, environment, source, project)
-		if apiErr != nil {
-			return apiErr
-		}
-
-		apiErr = h.pushFactsToLagoonApi(facts, resource)
-		if apiErr != nil {
-			return apiErr
-		}
+	apiErr = h.pushFactsToLagoonApi(facts, resource)
+	if apiErr != nil {
+		return apiErr
 	}
 
 	return nil
@@ -613,7 +608,7 @@ func (h *Messaging) sendToLagoonS3(incoming *InsightsMessage, insights InsightsD
 		log.Printf("Successfully created %s\n", h.S3Config.Bucket)
 	}
 
-	if incoming.Payload != nil {
+	if len(incoming.Payload) != 0 {
 		b, err := json.Marshal(incoming)
 		if err != nil {
 			return err
@@ -629,10 +624,12 @@ func (h *Messaging) sendToLagoonS3(incoming *InsightsMessage, insights InsightsD
 			return putObjErr
 		}
 
+		log.Println("--------------------")
 		log.Printf("Successfully uploaded %s of size %d\n", objectName, info.Size)
+		log.Println("--------------------")
 	}
 
-	if incoming.BinaryPayload != nil {
+	if len(incoming.BinaryPayload) != 0 {
 		for _, p := range incoming.BinaryPayload {
 			result, err := decodeGzipString(p)
 			if err != nil {
@@ -691,12 +688,18 @@ func (h *Messaging) pushFactsToLagoonApi(facts []lagoonclient.AddFactInput, reso
 	apiClient := graphql.NewClient(h.LagoonAPI.Endpoint, &http.Client{Transport: &authedTransport{wrapped: http.DefaultTransport, h: h}})
 
 	log.Println("--------------------")
-	log.Printf("Attempting to add %d facts...", len(facts))
+	log.Printf("Attempting to add %d fact/s...", len(facts))
 	log.Println("--------------------")
 
 	result, err := lagoonclient.AddFacts(context.TODO(), apiClient, facts)
 	if err != nil {
 		return err
+	}
+
+	if h.EnableDebug {
+		for _, fact := range facts {
+			log.Println("[DEBUG]...", fact.Name, ":", fact.Value)
+		}
 	}
 
 	log.Println(result)

--- a/internal/handler/testassets/testImageInspect.gz.json
+++ b/internal/handler/testassets/testImageInspect.gz.json
@@ -8,7 +8,7 @@
     "lagoon.sh/project": "high-cotton",
     "lagoon.sh/environment": "Master",
     "lagoon.sh/service": "cli",
-    "lagoon.sh/insightsType": "image-inspect-gz",
+    "lagoon.sh/insightsType": "image-gz",
     "lagoon.sh/insightsOutputCompressed": "true"
   }
 }

--- a/internal/handler/testassets/testImageInspectCompressedOutput.gz.json
+++ b/internal/handler/testassets/testImageInspectCompressedOutput.gz.json
@@ -8,7 +8,7 @@
     "lagoon.sh/project": "high-cotton",
     "lagoon.sh/environment": "Master",
     "lagoon.sh/service": "cli",
-    "lagoon.sh/insightsType": "image-inspect-gz",
+    "lagoon.sh/insightsType": "image-gz",
     "lagoon.sh/insightsOutputCompressed": "true"
   }
 }

--- a/key_facts.txt
+++ b/key_facts.txt
@@ -12,8 +12,8 @@ VARNISH_SIZE
 ##########################
 ## Packages
 ##########################
-drupal/core
-drush/drush
+(?i)drupal/core\b
+(?i)drush/drush\b
 #amazeeio/drupal_integrations
 #[dD]rupal/*.*
 #npm

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func main() {
 	flag.StringVar(&s3Region, "s3-region", "", "The s3 region.")
 	flag.BoolVar(&disableS3Upload, "disable-s3-upload", false, "Disable uploading insights data to an s3 s3Bucket")
 	flag.BoolVar(&disableAPIIntegration, "disable-api-integration", false, "Disable insights data integration for the Lagoon API")
+	flag.BoolVar(&enableDebug, "debug", false, "Enable debugging output")
 	flag.Parse()
 
 	// get overrides from environment variables
@@ -84,7 +85,6 @@ func main() {
 	s3Bucket = getEnv("S3_FILES_BUCKET", s3Bucket)
 	s3Region = getEnv("S3_FILES_REGION", s3Region)
 	useSSL := false
-	enableDebug := true
 
 	// configure the backup handler settings
 	broker := handler.RabbitBroker{


### PR DESCRIPTION
This PR reimplements the newest commits in https://github.com/uselagoon/lagoon/pull/2997 before it was closed.

It also fixes the image-inspect component to retrieve and post facts to the API.