### PR TITLE
Adds functionality to rename fact names if there are duplicates

### DIFF
--- a/internal/handler/fact_filters.go
+++ b/internal/handler/fact_filters.go
@@ -1,11 +1,33 @@
 package handler
 
+import "fmt"
+
 func KeyFactsFilter(factsInput []LagoonFact) ([]LagoonFact, error) {
 	var filteredFacts []LagoonFact
 	for _, v := range factsInput {
 		if v.KeyFact {
 			filteredFacts = append(filteredFacts, v)
 		}
+	}
+	return filteredFacts, nil
+}
+
+func FactDuplicateHandler(factsInput []LagoonFact) ([]LagoonFact, error) {
+
+	var factOccurenceTracker = map[string]int32{}
+
+	var filteredFacts []LagoonFact
+	for _, v := range factsInput {
+
+		if val, ok := factOccurenceTracker[v.Name]; ok {
+			factOccurenceTracker[v.Name] += 1
+			v.Name = fmt.Sprintf("%v [%v]", v.Name, val)
+		} else {
+			factOccurenceTracker[v.Name] = 1
+		}
+
+		filteredFacts = append(filteredFacts, v)
+
 	}
 	return filteredFacts, nil
 }

--- a/internal/handler/fact_filters_test.go
+++ b/internal/handler/fact_filters_test.go
@@ -1,0 +1,18 @@
+package handler
+
+import (
+	"testing"
+)
+
+func TestFactDuplicateHandler(t *testing.T) {
+	dupfacts := []LagoonFact{
+		{Name: "duplicatename"},
+		{Name: "duplicatename"},
+	}
+
+	outfacts, _ := FactDuplicateHandler(dupfacts)
+
+	if outfacts[0].Name == outfacts[1].Name {
+		t.Errorf("Fact names should not be duplicated")
+	}
+}

--- a/internal/handler/imageInspectParserFilter.go
+++ b/internal/handler/imageInspectParserFilter.go
@@ -55,6 +55,11 @@ func processImageInspectInsightsData(h *Messaging, insights InsightsData, v stri
 			return nil, "", err
 		}
 
+		facts, err = FactDuplicateHandler(facts)
+		if err != nil {
+			return nil, "", err
+		}
+
 		return facts, source, nil
 	}
 	return []LagoonFact{}, "", nil

--- a/internal/handler/insightsParserFilter.go
+++ b/internal/handler/insightsParserFilter.go
@@ -65,6 +65,11 @@ func processSbomInsightsData(h *Messaging, insights InsightsData, v string, apiC
 			return nil, "", err
 		}
 
+		facts, err = FactDuplicateHandler(facts)
+		if err != nil {
+			return nil, "", err
+		}
+
 		if len(facts) == 0 {
 			return nil, "", fmt.Errorf("no facts to process")
 		}


### PR DESCRIPTION
If, post filter and transformation, there is a duplicate named fact, this PR will add an index `[n]` (where n is an int > 0) to each fact subsequent to the first.