### PR TITLE
Fixes logic error and unmarshalling error

### DIFF
--- a/internal/handler/main.go
+++ b/internal/handler/main.go
@@ -325,6 +325,18 @@ func parserFilterLoopForPayloads(insights InsightsData, p PayloadInput, h *Messa
 
 // processResultset will send results as facts to the lagoon api after processing via a parser filter
 func processResultset(result []interface{}, err error, h *Messaging, apiClient graphql.Client, resource ResourceDestination, source string) {
+	project, environment, apiErr := determineResourceFromLagoonAPI(apiClient, resource)
+	if apiErr != nil {
+		log.Println(apiErr)
+	}
+
+	// Even if we don't find any new facts, we need to delete the existing ones
+	// since these may be the end product of a filter process
+	apiErr = h.deleteExistingFactsBySource(apiClient, environment, source, project)
+	if apiErr != nil {
+		log.Printf("%s", apiErr.Error())
+	}
+
 	for _, r := range result {
 		if fact, ok := r.(LagoonFact); ok {
 			// Handle single fact
@@ -343,23 +355,13 @@ func processResultset(result []interface{}, err error, h *Messaging, apiClient g
 }
 
 func (h *Messaging) sendFactsToLagoonAPI(facts []LagoonFact, apiClient graphql.Client, resource ResourceDestination, source string) error {
-	project, environment, apiErr := determineResourceFromLagoonAPI(apiClient, resource)
-	if apiErr != nil {
-		log.Println(apiErr)
-	}
-	if EnableDebug {
-		log.Printf("[DEBUG] matched %d number of fact(s) for '%v:%v', from source '%s'", len(facts), project.Name, environment, source)
-	}
 
-	// Even if we don't find any new facts, we need to delete the existing ones
-	// since these may be the end product of a filter process
-	apiErr = h.deleteExistingFactsBySource(apiClient, environment, source, project)
-	if apiErr != nil {
-		return fmt.Errorf("%s", apiErr.Error())
+	if EnableDebug {
+		log.Printf("[DEBUG] matched %d number of fact(s) for '%v:%v', from source '%s'", len(facts), resource.Project, resource.Environment, source)
 	}
 
 	if len(facts) > 0 {
-		apiErr = h.pushFactsToLagoonApi(facts, resource)
+		apiErr := h.pushFactsToLagoonApi(facts, resource)
 		if apiErr != nil {
 			return fmt.Errorf("%s", apiErr.Error())
 		}

--- a/internal/handler/registerFilters.go
+++ b/internal/handler/registerFilters.go
@@ -19,7 +19,7 @@ type FactTransformNameValue struct {
 type FactLookupNameValue struct {
 	Name       string `json:"name"`
 	Value      string `json:"value"`
-	ExactMatch bool   `json:"exactMatch"`
+	ExactMatch bool   `json:"exactMatch" yaml:"exactMatch"`
 }
 
 type FactTransform struct {


### PR DESCRIPTION
This PR fixes a long lived error in the fact deletion logic where, on processing a list of facts from the same source, the code was doing multiple deletions of the source - meaning that only the very last item was being written to the Facts DB.
This lifts the deletion logic _out_ of the loop that adds individual facts and, rather, clears facts by source for the entire set.

This PR also fixes a yaml unmarshalling regression introduced here https://github.com/uselagoon/insights-handler/pull/28

Visually - you can see the difference between how this is before the logic is fixed:
![image](https://github.com/uselagoon/insights-handler/assets/297936/057d28e6-1021-459a-976a-5cbffb8b6b54)


And now, with this PR:

![image](https://github.com/uselagoon/insights-handler/assets/297936/3099e1aa-64fa-478e-824e-ef10c84a58ea)

