### PR TITLE
fix: dont panic in processing, log the issue and move on

### DIFF
--- a/internal/handler/insightsFactsParserFilter.go
+++ b/internal/handler/insightsFactsParserFilter.go
@@ -53,7 +53,7 @@ func processFactsFromJSON(logger *slog.Logger, facts []byte, source string) []La
 	err := json.Unmarshal(facts, &factsPayload)
 	if err != nil {
 		logger.Error(err.Error())
-		panic("Can't unmarshal facts")
+		return nil
 	}
 
 	if len(factsPayload.Facts) == 0 {

--- a/internal/handler/insightsParserFilter.go
+++ b/internal/handler/insightsParserFilter.go
@@ -54,7 +54,8 @@ func processSbomInsightsData(h *Messaging, insights InsightsData, v string, apiC
 
 		decoder := cdx.NewBOMDecoder(bytes.NewReader(b), cdx.BOMFileFormatJSON)
 		if err = decoder.Decode(bom); err != nil {
-			panic(err)
+			logger.Error(err.Error())
+			return nil, "", mErr
 		}
 	}
 


### PR DESCRIPTION
To prevent the insights-handler from crashlooping when it encounters an issue decoding and enters a panic. This logs the error and returns a nil response so that processing of other messages can continue.

This will result in the data of the errored message potentially being lost though.

closes #59 