### PR TITLE
Fix - failing sbomcheck with empty components

### DIFF
--- a/internal/handler/insightsParserFilter.go
+++ b/internal/handler/insightsParserFilter.go
@@ -68,7 +68,7 @@ func processSbomInsightsData(h *Messaging, insights InsightsData, v string, apiC
 
 func processFactsFromSBOM(logger *slog.Logger, facts *[]cdx.Component, environmentId int, source string) []LagoonFact {
 	var factsInput []LagoonFact
-	if len(*facts) == 0 {
+	if facts == nil || len(*facts) == 0 {
 		return factsInput
 	}
 

--- a/internal/handler/testassets/testSbomPayloadNoComponents.json
+++ b/internal/handler/testassets/testSbomPayloadNoComponents.json
@@ -1,0 +1,21 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.3",
+  "serialNumber": "urn:uuid:db9b54af-f4ea-4043-9f53-b0f1b4485d4d",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2022-01-12T10:16:55Z",
+    "tools": [
+      {
+        "vendor": "anchore",
+        "name": "syft",
+        "version": "0.35.1"
+      }
+    ],
+    "component": {
+      "type": "container",
+      "name": "uselagoon/php-8.1-cli-drupal",
+      "version": "sha256:b364c41e9c6bf5dea414e3a382f8088883265a7ad48bfecc83c6ff2f75998d10"
+    }
+  }
+}


### PR DESCRIPTION
If an SBOM is processed with and Empty component field, currently insights will fail because of a failure to check for nil values.

This fixes that