### PR TITLE
test: add basic go test coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-TOKEN_SIGNING_KEY=abc123
+TOKEN_SIGNING_KEY=super-secret-string

--- a/.github/workflows/insights-handler.yaml
+++ b/.github/workflows/insights-handler.yaml
@@ -1,0 +1,34 @@
+name: Lagoon Insights Handler Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-suite:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: "0"
+    
+    - name: Set up testing dependencies
+      run: sudo apt-get update && sudo apt-get -y install build-essential && sudo apt-get clean
+
+    - name: Setup correct Go version
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.23'
+
+    - name: Run test
+      run: |
+        make test

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .env
 internal/handler/testassets/bin/*
 
+lagoon-core.*
 local-dev/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 internal/handler/testassets/bin/*
 
+local-dev/

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ ARCH := $(shell uname | tr '[:upper:]' '[:lower:]')
 
 TRIVY = $(realpath ./local-dev/trivy)
 
+CI_BUILD_TAG ?= insights
+CORE_REPO=https://github.com/uselagoon/lagoon.git
+CORE_TREEISH=main
+LAGOON_CORE_IMAGE_REPO=testlagoon
+LAGOON_CORE_IMAGE_TAG=main
+
 .PHONY: local-dev/trivy
 local-dev/trivy:
 ifeq ($(TRIVY_VERSION), $(shell trivy version 2>/dev/null | sed -nE 's/^Version: ([0-9.]+).*/\1/p'))
@@ -22,6 +28,29 @@ ifneq ($(TRIVY_VERSION), $(shell ./local-dev/trivy version 2>/dev/null | sed -nE
 	chmod a+x local-dev/trivy
 endif
 endif
+
+.PHONY: development-api
+development-api:
+	export LAGOON_CORE=$$(mktemp -d ./lagoon-core.XXX) \
+	&& export GRAPHQL_API=http://localhost:3000/graphql \
+	&& export KEYCLOAK_API=http://localhost:8088/auth \
+	&& git clone $(CORE_REPO) "$$LAGOON_CORE" \
+	&& cd "$$LAGOON_CORE" \
+	&& git checkout $(CORE_TREEISH) \
+	&& IMAGE_REPO=$(LAGOON_CORE_IMAGE_REPO) IMAGE_REPO_TAG=$(LAGOON_CORE_IMAGE_TAG) COMPOSE_STACK_NAME=core-$(CI_BUILD_TAG) docker compose -p core-$(CI_BUILD_TAG) pull \
+	&& IMAGE_REPO=$(LAGOON_CORE_IMAGE_REPO) IMAGE_REPO_TAG=$(LAGOON_CORE_IMAGE_TAG) COMPOSE_STACK_NAME=core-$(CI_BUILD_TAG) $(MAKE) compose-api-logs-development
+
+.PHONY: development-api-down
+development-api-down:
+	docker compose -p core-$(CI_BUILD_TAG) --compatibility down -v --remove-orphans
+
+# clean up any old charts to prevent bloating of old charts from running k3d stacks regularly
+.PHONY: clean-core
+clean-core: development-api-down
+	@for core in $$(ls -1 | grep -o "lagoon-core.*") ; do \
+		echo removing core directory $$core ; \
+		rm -rf $$core ; \
+	done
 
 .PHONY: runlocal
 runlocal:
@@ -43,7 +72,8 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+PATH := $(PATH):$(PWD)/local-dev
+
 .PHONY: test
-test: fmt vet local-dev/trivy
-	PATH=$$PATH:$(PWD)/local-dev
+test: fmt vet local-dev/trivy development-api
 	go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,49 @@
-.PHONY: gettrivy
-gettrivy:
-	mkdir -p internal/handler/testassets/bin/trivy/ && wget -O - https://github.com/aquasecurity/trivy/releases/download/v0.45.0/trivy_0.45.0_Linux-64bit.tar.gz | tar -zxvf - -C internal/handler/testassets/bin/trivy/
+SHELL := /bin/bash
 
+TRIVY_VERSION=0.45.0
+
+ARCH := $(shell uname | tr '[:upper:]' '[:lower:]')
+
+TRIVY = $(realpath ./local-dev/trivy)
+
+.PHONY: local-dev/trivy
+local-dev/trivy:
+ifeq ($(TRIVY_VERSION), $(shell trivy version 2>/dev/null | sed -nE 's/^Version: ([0-9.]+).*/\1/p'))
+	$(info linking local trivy version $(TRIVY_VERSION))
+	ln -sf $(shell command -v trivy) ./local-dev/trivy
+else
+ifneq ($(TRIVY_VERSION), $(shell ./local-dev/trivy version 2>/dev/null | sed -nE 's/^Version: ([0-9.]+).*/\1/p'))
+	$(info downloading trivy version $(TRIVY_VERSION) for $(ARCH))
+	mkdir -p local-dev
+	rm local-dev/trivy || true
+	TMPDIR=$$(mktemp -d) \
+		&& curl -sSL https://github.com/aquasecurity/trivy/releases/download/v$(TRIVY_VERSION)/trivy_$(TRIVY_VERSION)_$(ARCH)-64bit.tar.gz -o $$TMPDIR/trivy.tar.gz \
+		&& (cd $$TMPDIR && tar -zxf trivy.tar.gz) && cp $$TMPDIR/trivy ./local-dev/trivy && rm -rf $$TMPDIR
+	chmod a+x local-dev/trivy
+endif
+endif
 
 .PHONY: runlocal
 runlocal:
-	go run main.go --problems-from-sbom=true --rabbitmq-username=guest  --rabbitmq-password=guest --lagoon-api-host=http://localhost:8888/graphql   --jwt-token-signing-key=secret   --access-key-id=minio     --secret-access-key=minio123 --disable-s3-upload=true --debug=true
+	go run main.go --problems-from-sbom=true \
+		--rabbitmq-username=guest  \
+		--rabbitmq-password=guest \
+		--lagoon-api-host=http://localhost:8888/graphql \
+		--jwt-token-signing-key=secret \
+		--access-key-id=minio \
+		--secret-access-key=minio123 \
+		--disable-s3-upload=true \
+		--debug=true
 
+.PHONY: fmt
+fmt: ## Run go fmt against code.
+	go fmt ./...
 
+.PHONY: vet
+vet: ## Run go vet against code.
+	go vet ./...
+
+.PHONY: test
+test: fmt vet local-dev/trivy
+	PATH=$$PATH:$(PWD)/local-dev
+	go test -v ./...

--- a/internal/handler/FactDataTransformer.go
+++ b/internal/handler/FactDataTransformer.go
@@ -112,13 +112,10 @@ func typeMap(alias string) string {
 	switch alias {
 	case "EnvironmentVariable":
 		return "handler.EnvironmentVariable"
-		break
 	case "Package":
 		return "cyclonedx.Component"
-		break
 	case "InspectLabel":
 		return "handler.InsightsInspectLabel"
-		break
 	}
 	return alias
 }

--- a/internal/handler/FactDataTransformer_test.go
+++ b/internal/handler/FactDataTransformer_test.go
@@ -71,6 +71,9 @@ func TestFactProcessor_ProcessLagoonFactAgainstRegisteredFilters(t *testing.T) {
 		Category:    "",
 	}
 
+	poppedFactFilters := KeyFactFilters
+	defer func() { KeyFactFilters = poppedFactFilters }()
+
 	KeyFactFilters = []func(filter parserFilter) parserFilter{
 		func(filter parserFilter) parserFilter {
 			return filter.

--- a/internal/handler/FactDataTransformer_test.go
+++ b/internal/handler/FactDataTransformer_test.go
@@ -56,7 +56,7 @@ func TestFactProcessor_TestMultipleFilters(t *testing.T) {
 	}
 }
 
-//ProcessLagoonFactAgainstRegisteredFilters
+// ProcessLagoonFactAgainstRegisteredFilters
 func TestFactProcessor_ProcessLagoonFactAgainstRegisteredFilters(t *testing.T) {
 
 	fact := LagoonFact{


### PR DESCRIPTION
While doing a quick review on https://github.com/uselagoon/insights-handler/pull/97 I noticed there was no tests. This just adds a simple `go test` to a github action.

Edit: turns out, this requires a local lagoon too to run the tests against