### PR TITLE
feat: support for docker image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,8 @@ PATH := $(PATH):$(PWD)/local-dev
 .PHONY: test
 test: fmt vet local-dev/trivy development-api
 	go test -v ./...
+
+.PHONY: docker-build
+docker-build:
+	DOCKER_BUILDKIT=1 docker build --rm -f Dockerfile -t uselagoon/insights-handler:local .
+


### PR DESCRIPTION
# Description

Related to https://github.com/uselagoon/lagoon/pull/3970

This PR adds a handy make target to build a local image which can be used when developing locally with the Lagoon local-stack.