### PR TITLE
Update dependency versions in Dockerfile and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23-alpine3.19 AS builder
+FROM golang:1.26-alpine3.23 AS builder
 
 COPY . /go/src/github.com/uselagoon/lagoon/services/insights-handler/
 WORKDIR /go/src/github.com/uselagoon/lagoon/services/insights-handler/
@@ -15,7 +15,7 @@ COPY main.go main.go
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -o insights-handler main.go
 
 # we pull the trivy binary from aquasec's alpine based image
-FROM aquasec/trivy:0.69.1 AS trivy
+FROM aquasec/trivy:0.69.3 AS trivy
 
 # Use distroless as minimal base image to package the insights-handler binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 
+# renovate: datasource=docker depName=aquasec/trivy
 TRIVY_VERSION=0.69.3
 
 ARCH := $(shell uname | tr '[:upper:]' '[:lower:]')

--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,13 @@
     "dependencies"
   ],
   "dependencyDashboard": true,
-  "postUpdateOptions": ["gomodTidy","gomodUpdateImportPaths"]
+  "postUpdateOptions": ["gomodTidy","gomodUpdateImportPaths"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": ["# renovate: datasource=(?<datasource>[a-z]+) depName=(?<depName>[^\\n]+)\\n[A-Z_]+_VERSION=(?<currentValue>[0-9.]+)"],
+      "datasourceTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates dependencies to newer versions and improves automation for dependency management. The most significant changes are upgrading the Go and Trivy versions used in the build process, and enhancing the `renovate.json` configuration to better track Docker image versions defined in the `Makefile`.

Dependency upgrades:

* Upgraded the Go base image in the `Dockerfile` from `golang:1.23-alpine3.19` to `golang:1.26-alpine3.23`, ensuring the build uses a more recent Go version.
* Updated the Trivy image in the `Dockerfile` from `aquasec/trivy:0.69.1` to `aquasec/trivy:0.69.3` to include security and feature improvements.

Automation and dependency management:

* Enhanced the `renovate.json` configuration to add a custom manager that detects and updates Docker image versions specified in the `Makefile`, improving automated dependency tracking.