### PR TITLE
Migrate and update Renovate configuration and workflows

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -28,26 +28,26 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/insights-handler
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       -
         name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/insights-handler.yaml
+++ b/.github/workflows/insights-handler.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: "0"
     
@@ -25,7 +25,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get -y install build-essential && sudo apt-get clean
 
     - name: Setup correct Go version
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version: '1.26'
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,16 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-"config:recommended"
+  "baseBranches": [
+    "main"
   ],
+  "extends": [
+    "mergeConfidence:all-badges",
+    "config:recommended",
+    ":disableRateLimiting",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "dependencyDashboard": true,
   "postUpdateOptions": ["gomodTidy","gomodUpdateImportPaths"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+"config:recommended"
   ],
   "postUpdateOptions": ["gomodTidy","gomodUpdateImportPaths"]
 }


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use pinned digests for all third-party actions, ensuring more secure and predictable builds. Additionally, it improves the `renovate.json` configuration to enhance dependency management, labeling, and automation.

**GitHub Actions Security and Maintenance:**
* Updated all action references in `.github/workflows/build_and_publish.yml` and `.github/workflows/insights-handler.yaml` to use specific commit SHAs (pinned digests) instead of version tags, increasing security and preventing unexpected changes from upstream updates. [[1]](diffhunk://#diff-ebf33a46dfb7b44353d6b00f5978292fa922bcd221f948c81cd7aa3afd70e5baL19-R50) [[2]](diffhunk://#diff-b7aab758bd8eede151733356ffcc7e47a0035a0083333837309a65603c7bf903L20-R28)

**Renovate Configuration Improvements:**
* Enhanced `renovate.json` by:
  - Setting `main` as the base branch.
  - Extending with recommended and security-focused presets, disabling rate limiting, and enforcing GitHub Action digest pinning.
  - Adding a `dependencies` label to all PRs and enabling the dependency dashboard for better tracking.